### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.5"
 edition = "2021"
 license = "MIT"
 description = "This is library was created for simply programing CLI programs, with the simplest console graphical interface "
+repository = "https://github.com/dinskoy/mai"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
to allow crates.io, rust-digger, and others to link to it